### PR TITLE
Add contact page

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ This component outputs a list of blog post previews to be displayed on pages oth
 
 `max_num_posts` - Sets a limit on how many post previews to output.
 
-`show_excerpts`- If set to true, will show an excerpt from the blog post. The excerpt must be storedset in the front matter of the blog post.
+`show_excerpts`- If set to true, will show an excerpt from the blog post. The excerpt must be defined in the front matter of the blog post.
 
 **Example**
 

--- a/_includes/components/header.html
+++ b/_includes/components/header.html
@@ -85,7 +85,7 @@
               {%- if _section.class -%}
                 {% assign nav_item_class = _section.class %} 
               {%- elsif _section.href contains '/contact' -%}
-                {% assign nav_item_class = "an18f-button--dark margin-top-3 desktop:margin-top-0 margin-x-2"  %}
+                {% assign nav_item_class = "usa-button an18f-button--dark margin-top-3 desktop:margin-top-0 desktop:margin-x-2"  %}
               {%- else -%} 
                 {% assign nav_item_class = "usa-nav__link" %}
               {%- endif -%} 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,8 @@
 <footer>
   <div class="grid-container padding-y-6">
+    {% unless page.hide_footer_rule %}
     <hr class="hr-1-dark footer-hr-alignment"> 
+    {% endunless %}
     <div class="grid-row grid-gap">
       <div class="tablet:grid-col-3">
         <img src="{{ site.baseurl }}/assets/img/logos/18f-logo.svg"

--- a/_includes/usa-identifier.html
+++ b/_includes/usa-identifier.html
@@ -1,5 +1,5 @@
  {% assign anchor = site.data.usa_anchor.anchor_data[0] %}
-  <div class="usa-identifier">
+  <div class="usa-identifier padding-top-2">
     <section
       class="usa-identifier__section usa-identifier__section--masthead"
       aria-label="Agency identifier"

--- a/_layouts/styled-container.html
+++ b/_layouts/styled-container.html
@@ -3,6 +3,9 @@ layout: primary
 ---
 <section class="usa-section section-padding-top-0">
 <div class="grid-container"> 
+  {% if page.title_rule %}
+  <hr class="hr-1-dark margin-top-0 margin-bottom-8">
+  {% endif %}
   <div class="grid-row grid-gap">
     {%- if page.subnav_items or page.side_cta or page.social_media -%}
       <div class="tablet:grid-col-7">

--- a/_layouts/styled-container.html
+++ b/_layouts/styled-container.html
@@ -2,32 +2,32 @@
 layout: primary
 ---
 <section class="usa-section section-padding-top-0">
-<div class="grid-container"> 
-  {% if page.title_rule %}
-  <hr class="hr-1-dark margin-top-0 margin-bottom-8">
-  {% endif %}
-  <div class="grid-row grid-gap">
-    {%- if page.subnav_items or page.side_cta or page.social_media -%}
+  <div class="grid-container"> 
+    {% if page.title_rule %}
+    <hr class="hr-1-dark margin-top-0 margin-bottom-8">
+    {% endif %}
+    <div class="grid-row grid-gap">
+      {%- if page.subnav_items or page.side_cta or page.social_media -%}
       <div class="tablet:grid-col-7">
         {{ content }}
       </div>
       <aside class="tablet:grid-offset-1 tablet:grid-col-4 margin-bottom-2">
         {%- if page.subnav_items %} 
-          {% include navigation.html subnav=true %}
+        {% include navigation.html subnav=true %}
         {% endif %}
         {%- if page.side_cta -%} 
-          {% include side-cta.html %}
+        {% include side-cta.html %}
         {% endif -%}
         {%- if page.social_media -%} 
-          {% include social-media.html %}
+        {% include social-media.html %}
         {%- endif -%}
       </aside>
       {%- else -%}
       <div class="tablet:grid-col-8">
         {{ content }}
       </div>
-    {%- endif -%}
+      {%- endif -%}
+    </div>
   </div>
-</div>
 </section>
 

--- a/_layouts/styled-container.html
+++ b/_layouts/styled-container.html
@@ -4,23 +4,26 @@ layout: primary
 <section class="usa-section section-padding-top-0">
 <div class="grid-container"> 
   <div class="grid-row grid-gap">
-    {% if page.include_subnav or page.side_cta %}
-    <div class="tablet:grid-col-7">
-    {% else %}
-    <div class="tablet:grid-col-8">
-    {% endif %}
-      {{ content }}
-    </div>
-    {% if page.include_subnav or page.side_cta %}
-    <aside class="tablet:grid-offset-1 tablet:grid-col-4 margin-bottom-2">
-      {% if page.include_subnav %} 
-        {% include navigation.html subnav=true %}
-      {% endif %}
-      {% if page.side_cta %} 
-        {% include side-cta.html %}
-      {% endif %}
-    </aside>
-    {% endif %}
+    {%- if page.subnav_items or page.side_cta or page.social_media -%}
+      <div class="tablet:grid-col-7">
+        {{ content }}
+      </div>
+      <aside class="tablet:grid-offset-1 tablet:grid-col-4 margin-bottom-2">
+        {%- if page.subnav_items %} 
+          {% include navigation.html subnav=true %}
+        {% endif %}
+        {%- if page.side_cta -%} 
+          {% include side-cta.html %}
+        {% endif -%}
+        {%- if page.social_media -%} 
+          {% include social-media.html %}
+        {%- endif -%}
+      </aside>
+      {%- else -%}
+      <div class="tablet:grid-col-8">
+        {{ content }}
+      </div>
+    {%- endif -%}
   </div>
 </div>
 </section>

--- a/_principles/index.md
+++ b/_principles/index.md
@@ -3,7 +3,6 @@ title: 18F Partnership Principles
 permalink: /partnership-principles/
 layout: primary
 lead: Collaboration approaches to help your project succeed
-banner_cta: true
 subnav_items:
   - text: Methodologies
     permalink: /partnership-principles/#methodologies

--- a/_sass/_components/header.scss
+++ b/_sass/_components/header.scss
@@ -50,7 +50,7 @@
   .an18f-button--dark.usa-current, 
   .an18f-button--dark.usa-current:visited {
     background-color: color('accent-cool-lightest');
-    border: 2px solid color('primary-darkest');
+    outline: 2px solid color('primary-darkest');
 
     span {
       color: color('primary-darkest');

--- a/_sass/_components/header.scss
+++ b/_sass/_components/header.scss
@@ -49,26 +49,15 @@
 
   .an18f-button--dark.usa-current, 
   .an18f-button--dark.usa-current:visited {
-    background-color: color('primary-darkest');
+    background-color: color('accent-cool-lightest');
+    border: 2px solid color('primary-darkest');
 
     span {
-      color: white;
+      color: color('primary-darkest');
     }
 
     &:after {
-      background-color: white;
-      top: auto;
-      right: auto;
-      bottom: units(-0.5); 
-      left: auto;
-      height: units('2px');
-      width: 100%;
-      position: relative;
-
-      @include at-media('desktop') {
-        position: absolute;
-        width: auto;
-      }
+      width: 0;
     }
   }
 

--- a/_sass/_components/header.scss
+++ b/_sass/_components/header.scss
@@ -47,8 +47,29 @@
     color: white;
   }
 
-  .an18f-button--dark.usa-current span {
+  .an18f-button--dark.usa-current, 
+  .an18f-button--dark.usa-current:visited {
     background-color: color('primary-darkest');
+
+    span {
+      color: white;
+    }
+
+    &:after {
+      background-color: white;
+      top: auto;
+      right: auto;
+      bottom: units(-0.5); 
+      left: auto;
+      height: units('2px');
+      width: 100%;
+      position: relative;
+
+      @include at-media('desktop') {
+        position: absolute;
+        width: auto;
+      }
+    }
   }
 
   .usa-nav__secondary-links {

--- a/_sass/_components/hr.scss
+++ b/_sass/_components/hr.scss
@@ -1,0 +1,21 @@
+hr {
+  border: 1px solid color('primary-darker');
+  margin-top: units(6);
+  margin-bottom: units(4);
+}
+
+.hr-1-dark {
+  border: none;
+  border-top: 1px solid color('primary-dark');
+}
+
+.hr-1-base-lighter {
+  border: none;
+  border-top: 1px solid color('base-lighter');
+}
+
+.footer-hr-alignment {
+  margin-top: units(-6); 
+  margin-bottom: units(6);
+}
+

--- a/_sass/_components/utilities.scss
+++ b/_sass/_components/utilities.scss
@@ -10,26 +10,6 @@
   padding-top: units('2px');
 }
 
-hr {
-  border: 1px solid color('primary-darker');
-  margin-top: units(6);
-  margin-bottom: units(4);
-}
-
-.hr-1-dark {
-  border: none;
-  border-top: 1px solid color('primary-dark');
-}
-
-.hr-1-base-lighter {
-  border: none;
-  border-top: 1px solid color('base-lighter');
-}
-
-.footer-hr-alignment {
-  margin-top: calc(#{units(-6)} - 2px); // Extra 2px to hide the rule in the cta
-  margin-bottom: units(6);
-}
 
 // Sets the spacing of the list items on a unorded list (ul)
 .list-item-spacing-1 {

--- a/_sass/_uswds-theme-custom-styles.scss
+++ b/_sass/_uswds-theme-custom-styles.scss
@@ -14,6 +14,7 @@
 @import '_components/button';
 @import '_components/card-with-image';
 @import '_components/header';
+@import '_components/hr';
 @import '_components/section';
 @import '_components/quotemark';
 // @import '_components/nav-buttons';

--- a/blog/index.html
+++ b/blog/index.html
@@ -3,7 +3,6 @@ layout: primary
 title: 18F Blog
 lead: Delivering civic technology
 skip_index: true
-banner_cta: true
 redirect_from: "/2016/01/12/hacking-inclusion-by-customizing-a-slack-bot/"
 ---
 <section class="usa-section section-padding-top-0">

--- a/pages/contact.md
+++ b/pages/contact.md
@@ -4,9 +4,9 @@ permalink: /contact/
 layout: styled-container
 redirect_from: /hire/
 lead: Let’s work together to improve the user experience of government.
+title_rule: true
 social_media: true
 ---
-
 ### Want to see if 18F can help your agency?
 Contact our business development team at [inquiries18F@gsa.gov](mailto:inquiries18F@gsa.gov).
 

--- a/pages/contact.md
+++ b/pages/contact.md
@@ -1,15 +1,11 @@
 ---
 title: Contact
 permalink: /contact/
-layout: primary
-content_wide: true
+layout: styled-container
 redirect_from: /hire/
-gridless: true
 lead: Let’s work together to improve the user experience of government.
+social_media: true
 ---
-<div class="grid-container">
-  <div class="grid-row grid-gap">
-    <div class="usa-section tablet:grid-col-8" markdown="1">
 
 ### Want to see if 18F can help your agency?
 Contact our business development team at [inquiries18F@gsa.gov](mailto:inquiries18F@gsa.gov).
@@ -22,27 +18,3 @@ Reach out to GSA's media team at [press@gsa.gov](mailto:press@gsa.gov).
 
 ### Anything else?
 For other inquiries, contact our outreach team at [18F@gsa.gov](mailto:18F@gsa.gov).
-</div>
- <aside class="usa-section tablet:grid-col-4 col-last">
-      <h4 class="sidebar-heading-topic">Learn more about 18F</h4>
-        <ul>
-          <li><a href="{{ site.baseurl }}/our-work/">Past projects</a></li>
-          <li><a href="{{ site.baseurl }}/partnership-principles/">Partnership principles</a></li>
-          <li><a href="{{ site.baseurl }}/about/#funding-and-agreements">How we're funded</a></li>
-        </ul>
-        <h4 class="sidebar-heading-topic">Follow 18F</h4>
-        <ul class="usa-list usa-list--unstyled">
-          <li>
-            <!-- Inline CSS styles because these are only used this way here -->
-            <a href="https://twitter.com/18F"><img class="sidebar-icon-twitter" style="position: relative; top: 5px; left: -8px;" src="{{ site.baseurl }}/assets/img/social-icons/svg/twitter16.svg" alt="Twitter">@18F on Twitter</a>
-          </li>
-          <li>
-            <a href="https://github.com/18F"><img class="sidebar-icon-github" style="position: relative; top: 5px; margin-right: 25px;" src="{{ site.baseurl }}/assets/img/social-icons/svg/github.svg" alt="GitHub">18F on GitHub</a>
-          </li>
-          <li>
-            <a href="{{ site.baseurl }}/feed.xml"><img class="sidebar-icon-rss" style="position: relative; top: 5px; left: -9px; margin-right: 10px;" src="{{ site.baseurl }}/assets/img/social-icons/svg/rss25.svg" alt="RSS"/>RSS feed</a>
-          </li>
-        </ul>
-    </aside>
-</div>
-</div>

--- a/pages/guides.md
+++ b/pages/guides.md
@@ -3,7 +3,6 @@ title: Guides
 permalink: /guides/
 layout: primary
 lead: Principles and standards that shape our work
-banner_cta: true
 ---
 
 {% capture intro %}

--- a/pages/our-work.md
+++ b/pages/our-work.md
@@ -2,8 +2,7 @@
 title: Our work
 permalink: /our-work/
 lead: See how we’ve helped agencies deliver value to the American people.
-content_wide: true
-content_focus: false
+hide_footer_rule: true
 redirect_from:
   - /what-we-deliver/
   - /consulting/
@@ -12,7 +11,6 @@ redirect_from:
   - /what-we-deliver/micro-purchase-marketplace/
   - /what-we-deliver/ready-2-serve/
   - /what-we-deliver/new-ten/
-banner_cta: true
 ---
 
 <section class="bg-primary-darker usa-section--dark section-padding-md"> 

--- a/pages/work-with-us.md
+++ b/pages/work-with-us.md
@@ -2,9 +2,8 @@
 title: Work with us
 permalink: /work-with-us/
 lead: As federal employees, we share your dedication to serving the American&nbsp;public. 
-banner_cta: true
-content_focus: false
 redirect_from: /how-we-work/
+hide_footer_rule: true
 ---
 
 {% capture intro %}


### PR DESCRIPTION
# Pull request summary
This PR updates the contact page, adding in a few options to the `styled-container` template to allow the horizontal rule and social media include to be displayed on the page. Additionally it removes the CTA as decided in https://github.com/18F/TLC-crew/issues/397#issuecomment-1686622947. Consequently there a few updates to the footer `hr` since it can no longer be hidden in the CTA, and instead the PR adds an explict hide rule option.

👓 [Preview](https://federalist-c9d7d8a7-acd7-479e-9ab8-60987473d2d0.sites.pages.cloud.gov/preview/igorkorenfeld/18f.gsa.gov/ik/contact/contact/)